### PR TITLE
Update bootstrap-dynamic-tabs.js

### DIFF
--- a/bootstrap-dynamic-tabs/bootstrap-dynamic-tabs.js
+++ b/bootstrap-dynamic-tabs/bootstrap-dynamic-tabs.js
@@ -191,7 +191,7 @@
 
 			if(settings.ajaxUrl){
 				$.ajax({
-		            mimeType: 'text/html; charset=utf-8', // ! Need set mimeType only when run from local file
+		            //mimeType: 'text/html; charset=utf-8', // ! Need set mimeType only when run from local file
 		            url: settings.ajaxUrl,
 		            type: 'GET',
 		            success: function(data) {


### PR DESCRIPTION
Problema de encode com páginas iso-8859-1. Basta remover o parâmetro mimeType.

Ótimo trabalho.